### PR TITLE
Fix Django debug configuration in launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,35 +1,30 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {
             "name": "Python: Django Debug Single Test",
-            "python": "/home/vladimir/Sync/JA/ERM/gestor/gestorenv/bin/python3",
             "type": "python",
             "request": "launch",
             "program": "${workspaceFolder}/manage.py",
-            "console": "internalConsole",
             "args": [
                 "test",
                 "inventory" //"`echo -n ${relativeFileDirname} | tr \/ .`.${fileBasenameNoExtension}"
             ],
             "django": true,
+            "console": "integratedTerminal",
             "justMyCode": false
         },
         {
             "name": "Python: Django",
-            "python": "/home/vladimir/Sync/JA/ERM/gestor/gestorenv/bin/python3",
             "type": "python",
             "request": "launch",
             "program": "${workspaceFolder}/manage.py",
-            "console": "internalConsole",
             "args": [
                 "runserver"
             ],
             "django": true,
+            "console": "integratedTerminal",
             "justMyCode": false
-        },
+        }
     ]
 }


### PR DESCRIPTION
The commit fixes the debug configuration of Django in the launch.json file. It removes unnecessary attributes and sets the console attribute to "integratedTerminal" for both "Django Debug Single Test" and "Django" configurations.